### PR TITLE
Provide support for AirFlowMin/AirFlowMax command

### DIFF
--- a/pizone/zone.py
+++ b/pizone/zone.py
@@ -96,10 +96,6 @@ class Zone:
         Raises:
             AttributeError if the set point is out of range
         """
-        if self.type != Zone.Type.OPCL:
-            raise AttributeError(
-                'Can\'t set MinAir to \'{}\' type zone.'
-                .format(self.type))
         if value % 5 != 0:
             raise AttributeError(
                 'MinAir \'{}\' not rounded to nearest 5'
@@ -112,10 +108,9 @@ class Zone:
             return
 
         async with self._controller._sending_lock:
-            if self.mode != Zone.Mode.OPCL:
-                await self._send_command(
-                    'AirMinCommand',
-                    self._get_zone_state('MinAir'))
+            await self._send_command(
+                'AirMinCommand',
+                self._get_zone_state('MinAir'))
 
             # need to refresh immediatley after updating
             try:
@@ -132,10 +127,6 @@ class Zone:
         Raises:
             AttributeError if the set point is out of range
         """
-        if self.type != Zone.Type.OPCL:
-            raise AttributeError(
-                'Can\'t set MaxAir to \'{}\' type zone.'
-                .format(self.type))
         if value % 5 != 0:
             raise AttributeError(
                 'MaxAir \'{}\' not rounded to nearest 5'
@@ -148,10 +139,9 @@ class Zone:
             return
 
         async with self._controller._sending_lock:
-            if self.mode != Zone.Mode.OPCL:
-                await self._send_command(
-                    'AirMaxCommand',
-                    self._get_zone_state('MaxAir'))
+            await self._send_command(
+                'AirMaxCommand',
+                self._get_zone_state('MaxAir'))
 
             # need to refresh immediatley after updating
             try:

--- a/pizone/zone.py
+++ b/pizone/zone.py
@@ -108,9 +108,7 @@ class Zone:
             return
 
         async with self._controller._sending_lock:
-            await self._send_command(
-                'AirMinCommand',
-                self._get_zone_state('MinAir'))
+            await self._send_command('AirMinCommand', value)
 
             # need to refresh immediatley after updating
             try:
@@ -139,9 +137,7 @@ class Zone:
             return
 
         async with self._controller._sending_lock:
-            await self._send_command(
-                'AirMaxCommand',
-                self._get_zone_state('MaxAir'))
+            await self._send_command('AirMaxCommand', value)
 
             # need to refresh immediatley after updating
             try:
@@ -228,6 +224,6 @@ class Zone:
         self._controller._ensure_connected()  # pylint: disable=protected-access  # noqa
         return self._zone_data[state]
 
-    async def _send_command(self, command, data: Union[str, float]):
+    async def _send_command(self, command, data: Union[str, float, int]):
         send_data = {'ZoneNo': str(self._index+1), 'Command': str(data)}
         await self._controller._send_command_async(command, send_data)

--- a/pizone/zone.py
+++ b/pizone/zone.py
@@ -88,7 +88,7 @@ class Zone:
         """Min allowed airflow for the zone as a percent"""
         return self._get_zone_state('MinAir')
 
-   async def set_airflow_min(self, value: int) -> None:
+    async def set_airflow_min(self, value: int) -> None:
         """
         Change the zone airflow min in 5% increments
         Async method, returns when server has changed mode.
@@ -124,7 +124,7 @@ class Zone:
             except ConnectionError:
                 pass
 
-   async def set_airflow_max(self, value: int) -> None:
+    async def set_airflow_max(self, value: int) -> None:
         """
         Change the zone airflow max in 5% increments
         Async method, returns when server has changed mode.

--- a/pizone/zone.py
+++ b/pizone/zone.py
@@ -114,10 +114,11 @@ class Zone:
 
         async with self._controller._sending_lock:
             if self.mode != Zone.Mode.AUTO:
-                await self._send_zone_command(
+                await self._send_command(
+                    'ZoneCommand',
                     self._get_zone_state('SetPoint'))
             # This needs to be sent twice to work
-            await self._send_zone_command(value)
+            await self._send_command('ZoneCommand', value)
 
             # need to refresh immediatley after updating
             try:
@@ -138,10 +139,11 @@ class Zone:
                 if self.type != Zone.Type.AUTO:
                     raise AttributeError(
                         'Can\'t use auto mode on open/close zone.')
-                await self._send_zone_command(
+                await self._send_command(
+                    'ZoneCommand',
                     self._get_zone_state('SetPoint'))
             else:
-                await self._send_zone_command(value.value)
+                await self._send_command('ZoneCommand', value.value)
 
             # need to refresh immediatley after updating
             try:
@@ -164,6 +166,6 @@ class Zone:
         self._controller._ensure_connected()  # pylint: disable=protected-access  # noqa
         return self._zone_data[state]
 
-    async def _send_zone_command(self, data: Union[str, float]):
-        send_data = {'ZoneNo': str(self._index+1), 'Command': str(data)}
-        await self._controller._send_command_async('ZoneCommand', send_data)
+    async def _send_command(self, command, data: Union[str, float]):
+        send_data = {'ZoneNo': str(self._index+1), command: str(data)}
+        await self._controller._send_command_async('Command', send_data)

--- a/pizone/zone.py
+++ b/pizone/zone.py
@@ -229,5 +229,5 @@ class Zone:
         return self._zone_data[state]
 
     async def _send_command(self, command, data: Union[str, float]):
-        send_data = {'ZoneNo': str(self._index+1), command: str(data)}
-        await self._controller._send_command_async('Command', send_data)
+        send_data = {'ZoneNo': str(self._index+1), 'Command': str(data)}
+        await self._controller._send_command_async(command, send_data)


### PR DESCRIPTION
Hi @Swamp-Ig,

This is my first PR so please go easy on me!

I wanted to support the AirFlowMin/AirFlowMax command in your HA integration. I have refactored the zone _send_zone_command function to allow it to be used for the AirFlowMin/max calls as they are structurally the same.

Are you able to check if the code looks ok please? 