### PR TITLE
add 4 speed fan as unknown

### DIFF
--- a/pizone/controller.py
+++ b/pizone/controller.py
@@ -33,7 +33,7 @@ class Controller:
         LOW = 'low'
         MED = 'med'
         HIGH = 'high'
-        BOOST = 'top'
+        TOP = 'top'
         AUTO = 'auto'
 
     DictValue = Union[str, int, float]
@@ -47,7 +47,7 @@ class Controller:
 
     _VALID_FAN_MODES = {
         'disabled': [Fan.LOW, Fan.MED, Fan.HIGH],
-        'unknown': [Fan.LOW, Fan.MED, Fan.HIGH, Fan.BOOST, Fan.AUTO],
+        'unknown': [Fan.LOW, Fan.MED, Fan.HIGH, Fan.TOP, Fan.AUTO],
         '3-speed': [Fan.LOW, Fan.MED, Fan.HIGH, Fan.AUTO],
         '2-speed': [Fan.LOW, Fan.HIGH, Fan.AUTO],
         'var-speed': [Fan.LOW, Fan.MED, Fan.HIGH, Fan.AUTO],

--- a/pizone/controller.py
+++ b/pizone/controller.py
@@ -33,6 +33,7 @@ class Controller:
         LOW = 'low'
         MED = 'med'
         HIGH = 'high'
+        BOOST = 'top'
         AUTO = 'auto'
 
     DictValue = Union[str, int, float]
@@ -46,6 +47,7 @@ class Controller:
 
     _VALID_FAN_MODES = {
         'disabled': [Fan.LOW, Fan.MED, Fan.HIGH],
+        'unknown': [Fan.LOW, Fan.MED, Fan.HIGH, Fan.BOOST, Fan.AUTO],
         '3-speed': [Fan.LOW, Fan.MED, Fan.HIGH, Fan.AUTO],
         '2-speed': [Fan.LOW, Fan.HIGH, Fan.AUTO],
         'var-speed': [Fan.LOW, Fan.MED, Fan.HIGH, Fan.AUTO],


### PR DESCRIPTION
izone/airstream have advised that it is normal for FanAuto to report "unknown" when 4-speed is selected in the Auto Fan configuration on an iZone controller.

I have not been able to test this and may have missed another area where the code is affected by adding a new fan speed and mode.

![image](https://user-images.githubusercontent.com/24822223/122487285-3dd68f80-d01e-11eb-9b7b-a548bcfca378.png)
