### PR TITLE
Update controller.py

### DIFF
--- a/pizone/controller.py
+++ b/pizone/controller.py
@@ -54,6 +54,7 @@ class Controller:
     _VALID_FAN_MODES = {
         "disabled": [Fan.LOW, Fan.MED, Fan.HIGH],
         "unknown": [Fan.LOW, Fan.MED, Fan.HIGH, Fan.TOP, Fan.AUTO],
+        '4-speed': [Fan.LOW, Fan.MED, Fan.HIGH, Fan.TOP, Fan.AUTO],
         "3-speed": [Fan.LOW, Fan.MED, Fan.HIGH, Fan.AUTO],
         "2-speed": [Fan.LOW, Fan.HIGH, Fan.AUTO],
         "var-speed": [Fan.LOW, Fan.MED, Fan.HIGH, Fan.AUTO],


### PR DESCRIPTION
Added 4-speed valid fan mode to support firmware change to the COCB V4.16.  

This small change will allow newer iZone installations that use a 4 speed fan system to complete discovery on home assistant, currently any systems running the later firmwares will hit a fatal error during discovery within pizone.  

Note since V4.16 iZone fixed the firmware error that reported "unknown" when a 4 fan HVAC system was detected. Unfortunately my report to fix this long standing issue broken home assistant support.