### PR TITLE
Fix KeyError in controller_reconnected when UID not in _disconnected set

### DIFF
--- a/pizone/discovery.py
+++ b/pizone/discovery.py
@@ -142,7 +142,7 @@ class DiscoveryService:
                     ctrl.device_uid,
                     ctrl.device_ip,
                 )
-                _srv._disconnected.remove(ctrl.device_uid)
+                _srv._disconnected.discard(ctrl.device_uid)
                 for listener in _srv._listeners:
                     with LogExceptions("controller_reconnected"):
                         listener.controller_reconnected(ctrl)


### PR DESCRIPTION
Here is the PR body, cleanly formatted:

---

**Title:** `Fix KeyError in controller_reconnected when UID not in _disconnected set`

---

## Problem

When a controller connection fails, `_failed_connection` in `controller.py` has two early-return paths that skip firing `controller_disconnected`:

1. `if self._fail_exception: return` — a second failure while already in a failed state
2. `if not self._initialized: return` — failure before the controller is initialized

In both cases, `_disconnected.add(ctrl.device_uid)` is never called. However, `_retry_connection` unconditionally calls `controller_reconnected` on a successful reconnect, which in `discovery.py` line 113 calls:

```python
_srv._disconnected.remove(ctrl.device_uid)  # raises KeyError if UID was never added
```

This causes an uncaught `KeyError` logged at `pizone.discovery` on every reconnection cycle preceded by one of the skipped-disconnect paths. Home Assistant users see recurring `Uncaught exception` error log entries on every reconnect.

## Fix

Change `remove()` to `discard()` — a safe no-op when the key is absent:

```python
# pizone/discovery.py — _EventCoordinator.controller_reconnected, line 113

# Before:
_srv._disconnected.remove(ctrl.device_uid)

# After:
_srv._disconnected.discard(ctrl.device_uid)
```

## Impact

- No functional change to reconnection behaviour
- Eliminates the `KeyError` exception and the associated `Uncaught exception` log noise
- One-line change, no tests affected
