### PR TITLE
Allow zero-zone controller systems

### DIFF
--- a/pizone/controller.py
+++ b/pizone/controller.py
@@ -928,9 +928,9 @@ class Controller:
 
     @staticmethod
     def _system_settings_valid(values: ControllerData) -> bool:
-        """Return whether *values* look like healthy AC subsystem data."""
+        """Return whether *values* look healthy; unit-only systems have zero zones."""
         return (
-            int(values["NoOfZones"]) > 0
+            int(values["NoOfZones"]) >= 0
             and str(values["SysFan"]) != "error"
             and str(values["RAS"]) != "error"
         )

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -48,6 +48,25 @@ def _fault_system_settings(device_uid: str) -> dict[str, object]:
     return settings
 
 
+def _zero_zone_system_settings(device_uid: str) -> dict[str, object]:
+    settings = deepcopy(SYSTEMS["000000001"]["SystemSettings"])
+    settings.update(
+        {
+            "AirStreamDeviceUId": device_uid,
+            "SysOn": "off",
+            "SysMode": "cool",
+            "SysFan": "low",
+            "Setpoint": "22.0",
+            "RAS": "RAS",
+            "CtrlZone": 15,
+            "NoOfConst": 0,
+            "NoOfZones": 0,
+            "FanAuto": "disabled",
+        }
+    )
+    return settings
+
+
 # disposition: deprecate
 @pytest.mark.asyncio
 async def test_controller_property_reads(service: MockDiscoveryService) -> None:
@@ -377,6 +396,66 @@ async def test_v2_probe_clears_is_v2_on_http_error() -> None:
         controller = cast(MockController, svc._controllers["000000001"])
 
         assert controller.is_v2 is False
+    finally:
+        await svc.close()
+
+
+# disposition: deprecate
+@pytest.mark.asyncio
+async def test_zero_zone_system_initializes_controller() -> None:
+    svc = MockDiscoveryService()
+    controller = MockController.from_discovery(
+        svc,
+        svc._event_coordinator,
+        device_uid="000000004",
+        device_ip="10.0.0.4",
+        is_v2=False,
+        is_ipower=False,
+    )
+    settings = _zero_zone_system_settings(controller.device_uid)
+    controller.resources["SystemSettings"] = settings
+    svc._controllers[controller.device_uid] = controller
+
+    try:
+        await controller._initialize()
+
+        assert controller.bridge_connected is True
+        assert controller.connected is True
+        assert controller.dump_state()["system_settings"] == settings
+        assert controller.is_on is False
+        assert controller.mode == Controller.Mode.COOL
+        assert controller.fan == Controller.Fan.LOW
+        assert controller.temp_setpoint == pytest.approx(22.0)
+        assert controller.zones_total == 0
+        assert controller.zones == []
+    finally:
+        await svc.close()
+
+
+# disposition: deprecate
+@pytest.mark.asyncio
+async def test_negative_zone_count_marks_izone_not_ok() -> None:
+    svc = MockDiscoveryService()
+    controller = MockController.from_discovery(
+        svc,
+        svc._event_coordinator,
+        device_uid="000000004",
+        device_ip="10.0.0.4",
+        is_v2=False,
+        is_ipower=False,
+    )
+    settings = _zero_zone_system_settings(controller.device_uid)
+    settings["NoOfZones"] = -1
+    controller.resources["SystemSettings"] = settings
+    svc._controllers[controller.device_uid] = controller
+
+    try:
+        await controller._initialize()
+
+        assert controller.bridge_connected is True
+        assert controller.connected is False
+        assert controller.dump_state()["system_settings"] == {}
+        assert controller.zones == []
     finally:
         await svc.close()
 

--- a/tests/test_discovery_api.py
+++ b/tests/test_discovery_api.py
@@ -38,6 +38,7 @@ def _system_settings(uid: str) -> dict[str, object]:
         "SysOn": "on",
         "SysMode": "heat",
         "SysFan": "auto",
+        "RAS": "RAS",
         "NoOfZones": 0,
         "FanAuto": "disabled",
     }
@@ -708,6 +709,12 @@ async def test_create_controller_success() -> None:
     controller = await service.create_controller("000025841", "10.0.0.90")
     assert controller.device_uid == "000025841"
     assert controller.device_ip == "10.0.0.90"
+    assert controller.bridge_connected is True
+    assert controller.connected is True
+    assert controller.is_on is True
+    assert controller.mode == Controller.Mode.HEAT
+    assert controller.fan == Controller.Fan.AUTO
+    assert controller.zones == []
     assert service._claimed_endpoints["000025841"] == ControllerEndpoint(
         uid="000025841", host="10.0.0.90"
     )


### PR DESCRIPTION
## Summary

- allow valid unit-only iZone controllers with zero configured zones
- continue treating negative zone counts, `SysFan: "error"`, or `RAS: "error"` responses as subsystem faults
- cover zero-zone initialization through both legacy and 1.4 controller creation paths

## Testing

- `uv run pytest tests/test_controller.py::test_zero_zone_system_initializes_controller tests/test_discovery_api.py::test_create_controller_success -q`
- sabotage check: restoring the `NoOfZones > 0` predicate makes both zero-zone regression tests fail
- boundary check: removing numeric zone validation makes the negative-zone test fail
- `uv run pytest tests/test_controller.py tests/test_discovery_api.py -q`
- `./scripts/check` (Ruff, formatting, mypy, 157 tests with 3 deselected, package build)
- `git diff --check`

Fixes #33
